### PR TITLE
typescript3 seems necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository is a forking of the archived Heptio jsonnet extension to make it compatible for the latest vscode.  It is not currently published, but feel free to download and use the vsce tool to package it for your IDE.  Bug/feature submissions will also be considered.
 
+```
+npm i -D typescript@3
+npm i vsce -g
+vsce package
+code --install-extension jsonnet-0.1.0.vsix
+```
+
 [publishing/packaging]: https://code.visualstudio.com/api/working-with-extensions/publishing-extension
 
 # Jsonnet Support for Visual Studio Code


### PR DESCRIPTION
Having not much experience with the JS toolchain, it took me a while to figure out why I was seeing:
```
node_modules/@types/vscode/index.d.ts:7475:45 - error TS2304: Cannot find name 'unknown
```
It seems typescript3 is needed now. Hopefully this will save some time for others.